### PR TITLE
Added workaround for intermittent Adapt bug, simplified intents, removed unnecessary logs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1144,18 +1144,18 @@ class CPKodiSkill(CommonPlaySkill):
         if data['type'] == 'media':
             play_path(self.kodi_path, data['path'])
 
-    @intent_handler(IntentBuilder('WatchPVRChannelNumber').require("WatchKeyword")
-                    .require("PVRKeyword").optionally("ChannelNumber").build())
+    @intent_handler(IntentBuilder('').require("WatchKeyword").require("PVRKeyword").optionally("ChannelNumber"))
     def handle_channel(self, message):
         if 'ChannelNumber' in message.data:
             play_channel_number(self.kodi_path, int(message.data['ChannelNumber']))
             return
-        self.dLOG(str(dir(message)))
-        self.dLOG(str(message.data.keys()))
-        self.dLOG(str(message.data))
+        if channel_no := self._match_adapt_regex(message.data['utterance'], "ChannelNumber") is not None:
+            self.dLOG("Adapt failed to recognize an optional regex.")
+            play_channel_number(self.kodi_path, int(channel_no))
+            return
+        self.dLOG("Channel number not matched. Trying to find a channel name.")
         channel_query = message.utterance_remainder()
         channels = find_channel(self.kodi_path, channel_query)
-        self.dLOG(str(channels))
         if len(channels) == 0:
             self.speak_dialog('no.channel', data={'title':channel_query},
                               expect_response=False,
@@ -1164,7 +1164,7 @@ class CPKodiSkill(CommonPlaySkill):
         play_channel_number(self.kodi_path, int(channels[0]['channelid']))
 
     # user wants to open something from their favourites
-    @intent_handler(IntentBuilder('OpenFavorite').require("FavouritesKeyword").require("FavouriteTitle").build())
+    @intent_handler(IntentBuilder('').require("FavouritesKeyword").require("FavouriteTitle"))
     def handle_open_favourites_intent(self, message):
         favourite_query = message.data['FavouriteTitle']
 

--- a/kodi_tools/PlayPVR.py
+++ b/kodi_tools/PlayPVR.py
@@ -70,7 +70,6 @@ def find_channel(kodi_path, query):
         return None
     channel_list = channel_list['result']['channels']
     if len(channel_list) > 0:
-        LOG.info(channel_list)
         channel_list = [channel for channel in channel_list
                         if any(term in channel['label'] for term in search_filter)]
         def sortkey(channel):


### PR DESCRIPTION
This is an unfocused pull request, it does three things.

- There is an intermittent Adapt bug where optional regexes are not recognized by the intent engine despite matching. It isn't happening on this commit (but was before these changes), but I've included the workaround (new `__init__` lines starting at 1152) with a log message, so that I'll see it but users won't notice it.
- Removed some log messages which were used for writing PVR logic and are no longer needed. Replaced with a debug log to let a curious person know whether a channel command was interpreted as a number or channel name.
- Simplified intent decorators on the PVR and Favourite handlers outside of CPS. These decorators had gotten bad while trying to pinpoint the Adapt bug.